### PR TITLE
Add event factory methods returning a default event implementation

### DIFF
--- a/src/main/java/org/fountainmc/api/event/AbstractCancellable.java
+++ b/src/main/java/org/fountainmc/api/event/AbstractCancellable.java
@@ -1,0 +1,15 @@
+package org.fountainmc.api.event;
+
+public abstract class AbstractCancellable implements Cancellable {
+    private boolean cancelled = false;
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean value) {
+        this.cancelled = value;
+    }
+}

--- a/src/main/java/org/fountainmc/api/event/entity/EntityEvent.java
+++ b/src/main/java/org/fountainmc/api/event/entity/EntityEvent.java
@@ -1,10 +1,13 @@
 package org.fountainmc.api.event.entity;
 
+import javax.annotation.Nonnull;
+
 import org.fountainmc.api.entity.Entity;
 import org.fountainmc.api.event.Event;
 
 public interface EntityEvent extends Event {
 
+    @Nonnull
     Entity getEntity();
 
 }

--- a/src/main/java/org/fountainmc/api/event/entity/EntityRemovedEvent.java
+++ b/src/main/java/org/fountainmc/api/event/entity/EntityRemovedEvent.java
@@ -1,10 +1,43 @@
 package org.fountainmc.api.event.entity;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.fountainmc.api.entity.Entity;
+import org.fountainmc.api.event.AbstractCancellable;
 import org.fountainmc.api.event.Cancellable;
 import org.fountainmc.api.world.Location;
 
+import static com.google.common.base.Preconditions.*;
+
+@ParametersAreNonnullByDefault
 public interface EntityRemovedEvent extends EntityEvent, Cancellable {
 
+    @Nonnull
     Location getLocation();
 
+    @Nonnull
+    public static EntityRemovedEvent create(Entity entity) {
+        return create(entity, checkNotNull(entity, "Null entity").getLocation());
+    }
+
+    @Nonnull
+    public static EntityRemovedEvent create(Entity entity, Location location) {
+        checkArgument(checkNotNull(entity, "Null entity").getWorld().equals(checkNotNull(location, "Null location").getWorld()), "Entity's world %s doesn't match location's world %s", entity.getWorld(), location.getWorld());
+        class SimpleEntityRemovedEvent extends AbstractCancellable implements EntityRemovedEvent {
+
+            @Override
+            @Nonnull
+            public Location getLocation() {
+                return location;
+            }
+
+            @Override
+            @Nonnull
+            public Entity getEntity() {
+                return entity;
+            }
+        }
+        return new SimpleEntityRemovedEvent();
+    }
 }

--- a/src/main/java/org/fountainmc/api/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/fountainmc/api/event/entity/EntitySpawnEvent.java
@@ -1,10 +1,42 @@
 package org.fountainmc.api.event.entity;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.fountainmc.api.entity.Entity;
+import org.fountainmc.api.event.AbstractCancellable;
 import org.fountainmc.api.event.Cancellable;
 import org.fountainmc.api.world.Location;
 
+import static com.google.common.base.Preconditions.*;
+
+@ParametersAreNonnullByDefault
 public interface EntitySpawnEvent extends EntityEvent, Cancellable {
 
+    @Nonnull
     Location getLocation();
+
+    public static EntitySpawnEvent create(Entity entity) {
+        return create(entity, checkNotNull(entity, "Null entity").getLocation());
+    }
+
+    public static EntitySpawnEvent create(Entity entity, Location location) {
+        checkArgument(checkNotNull(entity, "Null entity").getWorld().equals(checkNotNull(location, "Null location").getWorld()), "Entity's world %s doesn't match location's world %s", entity.getWorld(), location.getWorld());
+        class SimpleEntitySpawnEvent extends AbstractCancellable implements EntitySpawnEvent {
+
+            @Override
+            @Nonnull
+            public Location getLocation() {
+                return location;
+            }
+
+            @Override
+            @Nonnull
+            public Entity getEntity() {
+                return entity;
+            }
+        }
+        return new SimpleEntitySpawnEvent();
+    }
 
 }

--- a/src/main/java/org/fountainmc/api/event/server/ServerStartEvent.java
+++ b/src/main/java/org/fountainmc/api/event/server/ServerStartEvent.java
@@ -1,10 +1,23 @@
 package org.fountainmc.api.event.server;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import org.fountainmc.api.Server;
+import org.fountainmc.api.event.AbstractCancellable;
 import org.fountainmc.api.event.Event;
 
+import static com.google.common.base.Preconditions.*;
+
+@ParametersAreNonnullByDefault
 public interface ServerStartEvent extends Event {
 
+    @Nonnull
     Server getServer();
+
+    public static ServerStartEvent create(Server server) {
+        checkNotNull(server, "Null server");
+        return () -> server;
+    }
 
 }

--- a/src/main/java/org/fountainmc/api/event/server/ServerStopEvent.java
+++ b/src/main/java/org/fountainmc/api/event/server/ServerStopEvent.java
@@ -1,6 +1,20 @@
 package org.fountainmc.api.event.server;
 
+import javax.annotation.Nonnull;
+
+import org.fountainmc.api.Server;
+import org.fountainmc.api.event.AbstractCancellable;
 import org.fountainmc.api.event.Event;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public interface ServerStopEvent extends Event {
+
+    @Nonnull
+    public Server getServer();
+
+    public static ServerStopEvent create(Server server) {
+        checkNotNull(server, "Null server");
+        return () -> server;
+    }
 }

--- a/src/main/java/org/fountainmc/api/event/world/BlockBreakEvent.java
+++ b/src/main/java/org/fountainmc/api/event/world/BlockBreakEvent.java
@@ -1,17 +1,54 @@
 package org.fountainmc.api.event.world;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.base.Preconditions;
+
 import org.fountainmc.api.entity.Player;
+import org.fountainmc.api.event.AbstractCancellable;
 import org.fountainmc.api.event.Cancellable;
 import org.fountainmc.api.event.Event;
 import org.fountainmc.api.world.BlockPosition;
 import org.fountainmc.api.world.block.BlockState;
 
+import static com.google.common.base.Preconditions.*;
+
+@ParametersAreNonnullByDefault
 public interface BlockBreakEvent extends Event, Cancellable {
 
+    @Nonnull
     BlockPosition getPosition();
 
+    @Nonnull
     BlockState getState();
 
+    @Nonnull
     Player getPlayer();
+
+    public static BlockBreakEvent create(Player player, BlockPosition position, BlockState state) {
+        checkArgument(checkNotNull(player, "Null player").getWorld().equals(checkNotNull(position, "Null position").getWorld()), "Player's world %s doesn't match position's world %s", player.getWorld(), position.getWorld());
+        checkNotNull(state, "Null state");
+        class SimpleBlockBreakEvent extends AbstractCancellable implements BlockBreakEvent {
+            @Nonnull
+            @Override
+            public BlockPosition getPosition() {
+                return position;
+            }
+
+            @Nonnull
+            @Override
+            public BlockState getState() {
+                return state;
+            }
+
+            @Nonnull
+            @Override
+            public Player getPlayer() {
+                return player;
+            }
+        }
+        return new SimpleBlockBreakEvent();
+    }
 
 }

--- a/src/main/java/org/fountainmc/api/event/world/ChunkEvent.java
+++ b/src/main/java/org/fountainmc/api/event/world/ChunkEvent.java
@@ -1,10 +1,13 @@
 package org.fountainmc.api.event.world;
 
+import javax.annotation.Nonnull;
+
 import org.fountainmc.api.event.Event;
 import org.fountainmc.api.world.Chunk;
 
 public interface ChunkEvent extends Event {
 
+    @Nonnull
     Chunk getChunk();
 
 }

--- a/src/main/java/org/fountainmc/api/event/world/ChunkLoadEvent.java
+++ b/src/main/java/org/fountainmc/api/event/world/ChunkLoadEvent.java
@@ -1,4 +1,17 @@
 package org.fountainmc.api.event.world;
 
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
+
+import org.fountainmc.api.world.Chunk;
+
+import static com.google.common.base.Preconditions.*;
+
 public interface ChunkLoadEvent extends ChunkEvent {
+    @Nonnull
+    public static ChunkLoadEvent create(@Nonnull Chunk chunk) {
+        checkNotNull(chunk, "Null chunk");
+        return () -> chunk;
+    }
 }

--- a/src/main/java/org/fountainmc/api/event/world/ChunkUnloadEvent.java
+++ b/src/main/java/org/fountainmc/api/event/world/ChunkUnloadEvent.java
@@ -1,4 +1,25 @@
 package org.fountainmc.api.event.world;
 
-public interface ChunkUnloadEvent extends ChunkEvent {
+import javax.annotation.Nonnull;
+
+import org.fountainmc.api.event.AbstractCancellable;
+import org.fountainmc.api.event.Cancellable;
+import org.fountainmc.api.world.Chunk;
+
+import static com.google.common.base.Preconditions.*;
+
+public interface ChunkUnloadEvent extends ChunkEvent, Cancellable {
+    @Nonnull
+    public static ChunkUnloadEvent create(@Nonnull Chunk chunk) {
+        checkNotNull(chunk, "Null chunk");
+        class SimpleChunkUnloadEvent extends AbstractCancellable implements ChunkUnloadEvent {
+
+            @Override
+            @Nonnull
+            public Chunk getChunk() {
+                return chunk;
+            }
+        }
+        return new SimpleChunkUnloadEvent();
+    }
 }


### PR DESCRIPTION
These event implementations aren't publicly accessible, so it'll be difficult for plugins to tie themselves to the implementaton.
Additionally, we don't have to fudge around with bytecode modification or double the number of files in the project.
