### PR TITLE
Fix version signature computation

### DIFF
--- a/utils.gradle
+++ b/utils.gradle
@@ -6,7 +6,7 @@ static String rawComputeVersionSignature(String version) {
     def versionBase = version.replace("-SNAPSHOT", "")
     // Determine the current git commit
     // Determine if there are uncommitted changes
-    def prog = "git status --porcelain=1".execute()
+    def prog = "git status --porcelain".execute()
     def isClean = prog.text.allWhitespace
     assert prog.waitFor() == 0, "Failed to execute git status!"
     /*


### PR DESCRIPTION
On Windows, and other versions of git (presumably) --porcelain does not take parameters. I assume =1 means to activate the parameter, and the standard --porcelain does this.